### PR TITLE
Add Darwin ARM64 as build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ build-linux: install-gox
 .PHONY: build-macOS
 build-macOS: install-gox
 	@$(GOX) -ldflags ${GO_LDFLAGS} --arch=amd64 --os=darwin --output="dist/helm_ls_{{.OS}}_{{.Arch}}"
+	@$(GOX) -ldflags ${GO_LDFLAGS} --arch=arm64 --os=darwin --output="dist/helm_ls_{{.OS}}_{{.Arch}}"
 
 .PHONY: build-windows
 build-windows: install-gox


### PR DESCRIPTION
This PR will create executables for Darwin ARM64 (Apple Silicon).