### PR TITLE
fix(lint): chart.yaml lint crash

### DIFF
--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -143,14 +143,17 @@ func GetDiagnosticFromLinterErr(supMsg support.Message) (*lsp.Diagnostic, string
 
 			fileLine := util.BetweenStrings(supMsg.Error(), "(", ")")
 			fileLineArr := strings.Split(fileLine, ":")
+			if len(fileLineArr) < 2 {
+				err = errors.Errorf("Linter Err contains no position information.")
+				return nil, filename, err
+			}
 			lineStr := fileLineArr[1]
-			msgStr := util.AfterStrings(supMsg.Error(), "):")
-			msg = strings.TrimSpace(msgStr)
-
 			line, err = strconv.Atoi(lineStr)
 			if err != nil {
 				return nil, filename, err
 			}
+			msgStr := util.AfterStrings(supMsg.Error(), "):")
+			msg = strings.TrimSpace(msgStr)
 
 		}
 

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -63,7 +63,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 	chartLoaded := linter.RunLinterRule(support.ErrorSev, fpath, err)
 
 	if !chartLoaded {
-		return
+		// ignoring this error and continuing with lint
 	}
 
 	options := chartutil.ReleaseOptions{


### PR DESCRIPTION
Otherwise an example Chart.yaml would crash the lsp

```yaml
apiVersion: v2
name: hello-world
description: A Helm chart for Kubernetes

type: application

version: ${release.version} # this is later interpolated by maven



```