### PR TITLE
Use WorkspaceFolders.URI rather than Name

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"path/filepath"
 
 	"github.com/mrjosh/helm-ls/internal/adapter/fs"
@@ -78,18 +79,23 @@ func (h *langHandler) handleInitialize(ctx context.Context, reply jsonrpc2.Repli
 		return errors.New("length WorkspaceFolders is 0")
 	}
 
-	vf := filepath.Join(params.WorkspaceFolders[0].Name, "values.yaml")
+	workspace_uri, err := url.Parse(params.WorkspaceFolders[0].URI)
+	if err != nil {
+		return err
+	}
+
+	vf := filepath.Join(workspace_uri.Path, "values.yaml")
 	vals, err := chartutil.ReadValuesFile(vf)
 	if err != nil {
-		logger.Println("Error loaing values.yaml file", err)
+		logger.Println("Error loading values.yaml file", err)
 		return err
 	}
 	h.values = vals
 
-	chartFile := filepath.Join(params.WorkspaceFolders[0].Name, "Chart.yaml")
+	chartFile := filepath.Join(workspace_uri.Path, "Chart.yaml")
 	chartMetadata, err := chartutil.LoadChartfile(chartFile)
 	if err != nil {
-		logger.Println("Error loaing Chart.yaml file", err)
+		logger.Println("Error loading Chart.yaml file", err)
 		return err
 	}
 	h.chartMetadata = *chartMetadata


### PR DESCRIPTION
Over in #37 I laid out the issue I was having: in the LSP docs, you can see that [`WorkspaceFolder`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceFolder)s have two fields: `Name` and `URI`.  My LSP client ([eglot](https://github.com/joaotavora/eglot)) is passing in a relativized URL so that `~/` appears in it - technically speaking, I could tweak what eglot is sending, but I think the best thing helm-ls could do is build the path stem to `values.yaml` and `Chart.yaml` based upon `URI` since we know it's going to be a [`URI`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uri)-conforming URL, so parsing it like this should always succeed.

I've tested this locally and it seems to work, and my gut feeling is that `URI` over `Name` is probably the right choice, but I'd love feedback. Hopefully this is a good and useful change for the language server.

Thanks for providing this project!

Resolves #37 