### PR TITLE
Add emacs instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,40 @@ lspconfig.helm_ls.setup {
 
 [![asciicast](https://asciinema.org/a/485522.svg)](https://asciinema.org/a/485522)
 
+## Emacs eglot setup
+
+Integrating helm-ls with [eglot](https://github.com/joaotavora/eglot) for emacs consists of two steps: wiring up Helm template files into a specific major mode and then associating that major mode with `helm_ls` via the `eglot-server-programs` variable.
+The first step is necessary because without a Helm-specific major mode, using an existing major mode like `yaml-mode` for `helm_ls` in `eglot-server-programs` may invoke the language server for other, non-Helm yaml files.
+
+For example, the following elisp snippet demonstrates how to use this language server after installing it as explained in [Getting Started](#getting-started).
+Assuming that you leverage `use-package` for package management:
+
+```elisp
+;; ...ensure that your package manager of choice is setup before
+;; installing packages, and then
+
+;; Install yaml-mode
+(use-package yaml-mode)
+
+;; Create a derived major-mode based on yaml-mode
+(define-derived-mode helm-mode yaml-mode "helm"
+  "Major mode for editing kubernetes helm templates")
+
+(use-package eglot
+  ; Any other existing eglot configuration plus the following:
+  :hook
+  ; Run eglot in helm-mode buffers
+  (helm-mode . eglot-ensure)
+  :config
+  ; Run `helm_ls serve` for helm-mode buffers
+  (add-to-list 'eglot-server-programs '(helm-mode "helm_ls" "serve")))
+```
+
+Invoke `M-x helm-mode` in a Helm template file to begin using helm-ls as a backend for eglot.
+Alternatively, you can include a comment such as the following at the top of Helm yaml files to automatically enter `helm-mode`:
+
+    # -*- mode: helm -*-
+
 ## Contributing
 Thank you for considering contributing to HelmLs project!
 


### PR DESCRIPTION
Per the suggestion in #38 , this updates the README to provide instructions for use with the emacs LSP package eglot.

This strategy works, although there may be a more elegant way than creating a bespoke `helm-mode`, but I'm not an elisp expert so I'm going with what I know works. :+1: 