### PR TITLE
Update Makefile - add darwin/arm64

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -48,6 +48,13 @@ jobs:
         path: ./dist/helm_ls-darwin-10.12-amd64
         retention-days: 1
 
+    - name: 'Upload macOS-arm64 artifact'
+      uses: actions/upload-artifact@v2
+      with:
+        name: helm_ls_darwin_arm64
+        path: ./dist/helm_ls-darwin-arm64
+        retention-days: 1
+
     - name: 'Upload linux/amd64 artifact'
       uses: actions/upload-artifact@v2
       with:
@@ -105,6 +112,11 @@ jobs:
         run: |
           sha256sum helm_ls_darwin_amd64/helm_ls-darwin-10.12-amd64 > helm_ls_darwin_amd64.sha256sum
           echo "SHA_MACOS=$(cat helm_ls_darwin_amd64.sha256sum)" >> $GITHUB_ENV
+          
+      - name: Generate macOS-ARM SHA256 checksums
+        run: |
+          sha256sum helm_ls_darwin_arm64/helm_ls-darwin-arm64 > helm_ls_darwin_arm64.sha256sum
+          echo "SHA_MACOS_ARM=$(cat helm_ls_darwin_arm64.sha256sum)" >> $GITHUB_ENV
 
       - name: Generate Linux-ARM SHA256 checksums
         run: |
@@ -129,6 +141,8 @@ jobs:
           files: |
             helm_ls_darwin_amd64:./helm_ls_darwin_amd64/helm_ls-darwin-10.12-amd64
             helm_ls_darwin_amd64.sha256sum:./helm_ls_darwin_amd64.sha256sum
+            helm_ls_darwin_arm64:./helm_ls_darwin_arm64/helm_ls-darwin-arm64
+            helm_ls_darwin_arm64.sha256sum:./helm_ls_darwin_arm64.sha256sum
             helm_ls_windows_amd64:./helm_ls_windows_amd64/helm_ls-windows-4.0-amd64.exe
             helm_ls_windows_amd64.sha256sum:./helm_ls_windows_amd64.sha256sum
             helm_ls_linux_amd64:./helm_ls_linux_amd64/helm_ls-linux-amd64
@@ -142,6 +156,9 @@ jobs:
             ### macOS (x64)
             1. Download **helm_ls_darwin_amd64**
             2. Run `./helm_ls_darwin_amd64`
+            ### macOS (ARM)
+            1. Download **helm_ls_darwin_arm64**
+            2. Run `./helm_ls_darwin_arm64`
             ### windows (x64)
             1. Download **helm_ls_windows_amd64.exe**
             2. Run `./helm_ls_windows_amd64.exe`
@@ -156,6 +173,7 @@ jobs:
             ```
             ${{ env.SHA_LINUX_64 }}
             ${{ env.SHA_MACOS }}
+            ${{ env.SHA_MACOS_ARM }}
             ${{ env.SHA_WINDOWS_64 }}
             ${{ env.SHA_LINUX_ARM }}
             ```

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build-linux: install-xgo
 
 .PHONY: build-macOS
 build-macOS: install-xgo
-	$(XGO) -dest dist -ldflags '$(GO_LDFLAGS)' -targets 'darwin-10.12/amd64' -out helm_ls .
+	$(XGO) -dest dist -ldflags '$(GO_LDFLAGS)' -targets 'darwin-10.12/amd64,darwin/arm64' -out helm_ls .
 
 .PHONY: build-windows
 build-windows: install-xgo


### PR DESCRIPTION
This should maybe generate a build for macOS ARM64 (AKA aarch).

fixes #40