### PR TITLE
[FIX] use goreleaser for cross compiling

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -15,16 +15,25 @@ on:
 
 jobs:
   artifacts:
-    runs-on: ubuntu-latest
+    name: artifacts
+    strategy:
+      matrix:
+        go-version: [1.19.1]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     outputs:
       version: ${{ steps.build.outputs.version }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v3
     - name: release publish
-      run: make build-release
+      run: |
+        make build-release
+        printf '::set-output name=version::%s\n' "$(./dist/linux-amd64_linux_amd64_v1/helm-ls version)"
 
     - name: 'Upload macOS-amd64 artifact'
       uses: actions/upload-artifact@v2

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -128,7 +128,7 @@ jobs:
             helm_ls_darwin_amd64.sha256sum:./helm_ls_darwin_amd64.sha256sum
             helm_ls_darwin_arm64:./helm_ls_darwin_arm64/helm-ls
             helm_ls_darwin_arm64.sha256sum:./helm_ls_darwin_arm64.sha256sum
-            helm_ls_windows_amd64:./helm_ls_windows_amd64/helm-ls.exe
+            helm_ls_windows_amd64.exe:./helm_ls_windows_amd64/helm-ls.exe
             helm_ls_windows_amd64.sha256sum:./helm_ls_windows_amd64.sha256sum
             helm_ls_linux_amd64:./helm_ls_linux_amd64/helm-ls
             helm_ls_linux_amd64.sha256sum:./helm_ls_linux_amd64.sha256sum

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -14,59 +14,51 @@ on:
       - v*
 
 jobs:
-
   artifacts:
-    name: artifacts
-    strategy:
-      matrix:
-        go-version: [1.19.1]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.build.outputs.version }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v4
-      with:
-        go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v3
-
-    - name: Install go dependencies
-      run: go mod tidy
-
-    - name: Build artifacts
-      id: build
-      run: |
-        make build-artifacts
-        printf '::set-output name=version::%s\n' "$(./dist/helm_ls_linux_amd64 version)"
+    - name: release publish
+      run: make build-release
 
     - name: 'Upload macOS-amd64 artifact'
       uses: actions/upload-artifact@v2
       with:
         name: helm_ls_darwin_amd64
-        path: ./dist/helm_ls-darwin-10.12-amd64
+        path: ./dist/darwin-amd64_darwin_amd64_v1/helm-ls
+        retention-days: 1
+
+    - name: 'Upload macOS-arm64 artifact'
+      uses: actions/upload-artifact@v2
+      with:
+        name: helm_ls_darwin_arm64
+        path: ./dist/darwin-arm64_darwin_arm64/helm-ls
         retention-days: 1
 
     - name: 'Upload linux/amd64 artifact'
       uses: actions/upload-artifact@v2
       with:
         name: helm_ls_linux_amd64
-        path: ./dist/helm_ls-linux-amd64
+        path: ./dist/linux-amd64_linux_amd64_v1/helm-ls
         retention-days: 1
 
     - name: 'Upload linux/arm artifact'
       uses: actions/upload-artifact@v2
       with:
         name: helm_ls_linux_arm
-        path: ./dist/helm_ls-linux-arm64
+        path: ./dist/linux-arm64_linux_arm64/helm-ls
         retention-days: 1
 
     - name: 'Upload windows/amd64 artifact'
       uses: actions/upload-artifact@v2
       with:
         name: helm_ls_windows_amd64
-        path: ./dist/helm_ls-windows-4.0-amd64.exe
+        path: ./dist/windows-amd64_windows_amd64_v1/helm-ls.exe
         retention-days: 1
 
   publish:
@@ -93,22 +85,27 @@ jobs:
 
       - name: Generate Linux-64 SHA256 checksums
         run: |
-          sha256sum helm_ls_linux_amd64/helm_ls-linux-amd64 > helm_ls_linux_amd64.sha256sum
+          sha256sum helm_ls_linux_amd64/helm-ls > helm_ls_linux_amd64.sha256sum
           echo "SHA_LINUX_64=$(cat helm_ls_linux_amd64.sha256sum)" >> $GITHUB_ENV
 
       - name: Generate Windows-64 SHA256 checksums
         run: |
-          sha256sum helm_ls_windows_amd64/helm_ls-windows-4.0-amd64.exe > helm_ls_windows_amd64.sha256sum
+          sha256sum helm_ls_windows_amd64/helm-ls.exe > helm_ls_windows_amd64.sha256sum
           echo "SHA_WINDOWS_64=$(cat helm_ls_windows_amd64.sha256sum)" >> $GITHUB_ENV
 
       - name: Generate macOS-amd64 SHA256 checksums
         run: |
-          sha256sum helm_ls_darwin_amd64/helm_ls-darwin-10.12-amd64 > helm_ls_darwin_amd64.sha256sum
-          echo "SHA_MACOS=$(cat helm_ls_darwin_amd64.sha256sum)" >> $GITHUB_ENV
+          sha256sum helm_ls_darwin_amd64/helm-ls > helm_ls_darwin_amd64.sha256sum
+          echo "SHA_MACOS_AMD64=$(cat helm_ls_darwin_amd64.sha256sum)" >> $GITHUB_ENV
+
+      - name: Generate macOS-arm64 SHA256 checksums
+        run: |
+          sha256sum helm_ls_darwin_arm64/helm-ls > helm_ls_darwin_arm64.sha256sum
+          echo "SHA_MACOS_ARM64=$(cat helm_ls_darwin_arm64.sha256sum)" >> $GITHUB_ENV
 
       - name: Generate Linux-ARM SHA256 checksums
         run: |
-          sha256sum helm_ls_linux_arm/helm_ls-linux-arm64 > helm_ls_linux_arm.sha256sum
+          sha256sum helm_ls_linux_arm/helm-ls > helm_ls_linux_arm.sha256sum
           echo "SHA_LINUX_ARM=$(cat helm_ls_linux_arm.sha256sum)" >> $GITHUB_ENV
 
       - if: env.TAG_NAME == 'master'
@@ -127,13 +124,15 @@ jobs:
           gzip: false
           allow_override: true
           files: |
-            helm_ls_darwin_amd64:./helm_ls_darwin_amd64/helm_ls-darwin-10.12-amd64
+            helm_ls_darwin_amd64:./helm_ls_darwin_amd64/helm-ls
             helm_ls_darwin_amd64.sha256sum:./helm_ls_darwin_amd64.sha256sum
-            helm_ls_windows_amd64:./helm_ls_windows_amd64/helm_ls-windows-4.0-amd64.exe
+            helm_ls_darwin_arm64:./helm_ls_darwin_arm64/helm-ls
+            helm_ls_darwin_arm64.sha256sum:./helm_ls_darwin_arm64.sha256sum
+            helm_ls_windows_amd64:./helm_ls_windows_amd64/helm-ls.exe
             helm_ls_windows_amd64.sha256sum:./helm_ls_windows_amd64.sha256sum
-            helm_ls_linux_amd64:./helm_ls_linux_amd64/helm_ls-linux-amd64
+            helm_ls_linux_amd64:./helm_ls_linux_amd64/helm-ls
             helm_ls_linux_amd64.sha256sum:./helm_ls_linux_amd64.sha256sum
-            helm_ls_linux_arm:./helm_ls_linux_arm/helm_ls-linux-arm64
+            helm_ls_linux_arm:./helm_ls_linux_arm/helm-ls
             helm_ls_linux_arm.sha256sum:./helm_ls_linux_arm.sha256sum
           body: |
             ```
@@ -142,6 +141,9 @@ jobs:
             ### macOS (x64)
             1. Download **helm_ls_darwin_amd64**
             2. Run `./helm_ls_darwin_amd64`
+            ### macOS (ARM)
+            1. Download **helm_ls_darwin_arm64**
+            2. Run `./helm_ls_darwin_arm64`
             ### windows (x64)
             1. Download **helm_ls_windows_amd64.exe**
             2. Run `./helm_ls_windows_amd64.exe`
@@ -155,7 +157,8 @@ jobs:
             
             ```
             ${{ env.SHA_LINUX_64 }}
-            ${{ env.SHA_MACOS }}
+            ${{ env.SHA_MACOS_AMD64 }}
+            ${{ env.SHA_MACOS_ARM64 }}
             ${{ env.SHA_WINDOWS_64 }}
             ${{ env.SHA_LINUX_ARM }}
             ```

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X main.Version={{ .Env.GIT_COMMIT }} -X main.CompiledBy={{ .Env.COMPILED_BY }}  -X main.BranchName={{ .Env.BRANCH_NAME }} -X main.BuildTime={{ .Env.BUILD_TIME }}
   - id: darwin-arm64
     binary: helm-ls
     main: ./
@@ -24,13 +24,9 @@ builds:
       - CC=oa64-clang
       - CXX=oa64-clang++
     flags:
-      # - "-mod={{ .Env.MOD }}"
-      # - "-tags={{ .Env.BUILD_TAGS }}"
       - -trimpath
-    # ldflags:
-    #   - "{{ .Env.BUILD_VARS }}"
-    #   - "{{ .Env.STRIP_FLAGS }}"
-    #   - "-linkmode={{ .Env.LINKMODE }}"
+    ldflags:
+      - -X main.Version={{ .Env.GIT_COMMIT }} -X main.CompiledBy={{ .Env.COMPILED_BY }}  -X main.BranchName={{ .Env.BRANCH_NAME }} -X main.BuildTime={{ .Env.BUILD_TIME }}
   - id: linux-amd64
     main: ./
     binary: helm-ls
@@ -41,7 +37,7 @@ builds:
     flags:
       - -mod=readonly
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X main.Version={{ .Env.GIT_COMMIT }} -X main.CompiledBy={{ .Env.COMPILED_BY }}  -X main.BranchName={{ .Env.BRANCH_NAME }} -X main.BuildTime={{ .Env.BUILD_TIME }}
   - id: linux-arm64
     main: ./
     binary: helm-ls
@@ -55,7 +51,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X main.Version={{ .Env.GIT_COMMIT }} -X main.CompiledBy={{ .Env.COMPILED_BY }}  -X main.BranchName={{ .Env.BRANCH_NAME }} -X main.BuildTime={{ .Env.BUILD_TIME }}
   - id: windows-amd64
     main: ./
     binary: helm-ls
@@ -69,6 +65,8 @@ builds:
     flags:
       - -trimpath
       - -buildmode=exe
+    ldflags:
+      - -X main.Version={{ .Env.GIT_COMMIT }} -X main.CompiledBy={{ .Env.COMPILED_BY }}  -X main.BranchName={{ .Env.BRANCH_NAME }} -X main.BuildTime={{ .Env.BUILD_TIME }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,82 @@
+builds:
+  - id: darwin-amd64
+    main: ./
+    binary: helm-ls
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+  - id: darwin-arm64
+    binary: helm-ls
+    main: ./
+    goarch:
+      - arm64
+    goos:
+      - darwin
+    env:
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    flags:
+      # - "-mod={{ .Env.MOD }}"
+      # - "-tags={{ .Env.BUILD_TAGS }}"
+      - -trimpath
+    # ldflags:
+    #   - "{{ .Env.BUILD_VARS }}"
+    #   - "{{ .Env.STRIP_FLAGS }}"
+    #   - "-linkmode={{ .Env.LINKMODE }}"
+  - id: linux-amd64
+    main: ./
+    binary: helm-ls
+    goos:
+      - linux
+    goarch:
+      - amd64
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+  - id: linux-arm64
+    main: ./
+    binary: helm-ls
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+  - id: windows-amd64
+    main: ./
+    binary: helm-ls
+    goarch:
+      - amd64
+    goos:
+      - windows
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    flags:
+      - -trimpath
+      - -buildmode=exe
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ build-release:
 	@docker run \
 			--rm \
 			-e CGO_ENABLED=1 \
+			-e COMPILED_BY=$(COMPILED_BY) \
+			-e BRANCH_NAME=$(BRANCH_NAME) \
+			-e BUILD_TIME=$(BUILD_TIME) \
+			-e GIT_COMMIT=$(GIT_COMMIT) \
 			-v /var/run/docker.sock:/var/run/docker.sock \
 			-v `pwd`:/go/src/$(PACKAGE_NAME) \
 			-w /go/src/$(PACKAGE_NAME) \


### PR DESCRIPTION
This uses https://github.com/goreleaser/goreleaser-cross instead of xgo to cross compile the releases.

The binaries can be downloaded from [here](https://github.com/qvalentin/helm-ls/releases/tag/test-release) to test these changes.

Tested:

- [x] MacOS x86
- [x] MacOS ARM
- [x] Linux x86
- [ ] Linux ARM
- [x] Windows x86

fixes https://github.com/mrjosh/helm-ls/issues/40 and https://github.com/mrjosh/helm-ls/issues/35.