### PR TITLE
[Fix] don't crash if values.yaml or Chart.yaml is not found

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -88,7 +88,6 @@ func (h *langHandler) handleInitialize(ctx context.Context, reply jsonrpc2.Repli
 	vals, err := chartutil.ReadValuesFile(vf)
 	if err != nil {
 		logger.Println("Error loading values.yaml file", err)
-		return err
 	}
 	h.values = vals
 
@@ -96,7 +95,6 @@ func (h *langHandler) handleInitialize(ctx context.Context, reply jsonrpc2.Repli
 	chartMetadata, err := chartutil.LoadChartfile(chartFile)
 	if err != nil {
 		logger.Println("Error loading Chart.yaml file", err)
-		return err
 	}
 	h.chartMetadata = *chartMetadata
 


### PR DESCRIPTION
Instead the default values are used, this would be the same as if the file was empty.

This makes it possible to use helm-ls for helmfile projects that don't have a values.yaml file (https://github.com/mrjosh/helm-ls/issues/27).