### PR TITLE
fix(yamlls): trim some templates better

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "master"
   pull_request:
-    types: [synchronize]
 
 jobs:
 

--- a/internal/adapter/yamlls/diagnostics.go
+++ b/internal/adapter/yamlls/diagnostics.go
@@ -50,7 +50,7 @@ func filterDiagnostics(diagnostics []lsp.Diagnostic, ast *sitter.Tree, content s
 }
 
 func diagnisticIsRelevant(diagnostic lsp.Diagnostic, node *sitter.Node) bool {
-	logger.Debug("Diagnostic", diagnostic.Message)
+	logger.Debug("Checking if diagnostic is relevant", diagnostic.Message)
 	switch diagnostic.Message {
 	case "Map keys must be unique":
 		return !lsplocal.IsInElseBranch(node)

--- a/internal/adapter/yamlls/diagnostics.go
+++ b/internal/adapter/yamlls/diagnostics.go
@@ -60,6 +60,13 @@ func diagnisticIsRelevant(diagnostic lsp.Diagnostic, node *sitter.Node) bool {
 		"A block sequence may not be used as an implicit map key":
 		// TODO: could add a check if is is caused by includes
 		return false
+	case "Block scalars with more-indented leading empty lines must use an explicit indentation indicator":
+		return false
+		// TODO: check if this is a false positive, probably requires parsing the yaml with tree-sitter injections
+		// smtp-password: |
+		//   {{- if not .Values.existingSecret }}
+		//   test: dsa
+		//   {{- end }}
 
 	default:
 		return true

--- a/internal/adapter/yamlls/diagnostics.go
+++ b/internal/adapter/yamlls/diagnostics.go
@@ -21,7 +21,7 @@ func (yamllsConnector *Connector) handleDiagnostics(req jsonrpc2.Request, client
 		logger.Println("Error handling diagnostic. Could not get document: " + params.URI.Filename())
 	}
 
-	doc.DiagnosticsCache.SetYamlDiagnostics(filterDiagnostics(params.Diagnostics, doc.Ast, doc.Content))
+	doc.DiagnosticsCache.SetYamlDiagnostics(filterDiagnostics(params.Diagnostics, doc.Ast.Copy(), doc.Content))
 	if doc.DiagnosticsCache.ShouldShowDiagnosticsOnNewYamlDiagnostics() {
 		logger.Debug("Publishing yamlls diagnostics")
 		params.Diagnostics = doc.DiagnosticsCache.GetMergedDiagnostics()
@@ -64,5 +64,4 @@ func diagnisticIsRelevant(diagnostic lsp.Diagnostic, node *sitter.Node) bool {
 	default:
 		return true
 	}
-
 }

--- a/internal/adapter/yamlls/trimTemplate.go
+++ b/internal/adapter/yamlls/trimTemplate.go
@@ -6,13 +6,13 @@ import (
 )
 
 func trimTemplateForYamllsFromAst(ast *sitter.Tree, text string) string {
-	var result = []byte(text)
+	result := []byte(text)
 	prettyPrintNode(ast.RootNode(), []byte(text), result)
 	return string(result)
 }
 
 func prettyPrintNode(node *sitter.Node, previous []byte, result []byte) {
-	var childCount = node.ChildCount()
+	childCount := node.ChildCount()
 
 	switch node.Type() {
 	case gotemplate.NodeTypeIfAction:
@@ -23,7 +23,7 @@ func prettyPrintNode(node *sitter.Node, previous []byte, result []byte) {
 		earaseTemplate(node, previous, result)
 	case gotemplate.NodeTypeFunctionCall:
 		trimFunctionCall(node, previous, result)
-	case gotemplate.NodeTypeComment, gotemplate.NodeTypeVariableDefinition:
+	case gotemplate.NodeTypeComment, gotemplate.NodeTypeVariableDefinition, gotemplate.NodeTypeAssignment:
 		earaseTemplateAndSiblings(node, previous, result)
 	default:
 		for i := 0; i < int(childCount); i++ {
@@ -37,6 +37,7 @@ func trimAction(childCount uint32, node *sitter.Node, previous []byte, result []
 		child := node.Child(i)
 		switch child.Type() {
 		case
+			gotemplate.NodeTypeAssignment,
 			gotemplate.NodeTypeIf,
 			gotemplate.NodeTypeSelectorExpression,
 			gotemplate.NodeTypeElse,
@@ -52,6 +53,7 @@ func trimAction(childCount uint32, node *sitter.Node, previous []byte, result []
 			gotemplate.NodeTypeInterpretedStringLiteral,
 			gotemplate.NodeTypeBlock,
 			gotemplate.NodeTypeVariableDefinition,
+			gotemplate.NodeTypeVariable,
 			gotemplate.NodeTypeRangeVariableDefinition:
 			earaseTemplate(child, previous, result)
 		default:
@@ -94,7 +96,7 @@ func trimFunctionCall(node *sitter.Node, previous []byte, result []byte) {
 
 func earaseTemplateAndSiblings(node *sitter.Node, previous []byte, result []byte) {
 	earaseTemplate(node, previous, result)
-	var prevSibling, nextSibling = node.PrevSibling(), node.NextSibling()
+	prevSibling, nextSibling := node.PrevSibling(), node.NextSibling()
 	if prevSibling != nil {
 		earaseTemplate(prevSibling, previous, result)
 	}
@@ -107,8 +109,11 @@ func earaseTemplate(node *sitter.Node, previous []byte, result []byte) {
 	if node == nil {
 		return
 	}
-	logger.Println("Content that is earased", node.Content(previous))
+	logger.Debug("Content that is erased", node.Content(previous))
 	for i := range []byte(node.Content(previous)) {
-		result[int(node.StartByte())+i] = byte(' ')
+		index := int(node.StartByte()) + i
+		if result[index] != '\n' && result[index] != '\r' {
+			result[index] = byte(' ')
+		}
 	}
 }

--- a/internal/adapter/yamlls/trimTemplate.go
+++ b/internal/adapter/yamlls/trimTemplate.go
@@ -63,6 +63,11 @@ func trimAction(childCount uint32, node *sitter.Node, previous []byte, result []
 }
 
 func trimIfAction(node *sitter.Node, previous []byte, result []byte) {
+	if node.StartPoint().Row == node.EndPoint().Row {
+		earaseTemplate(node, previous, result)
+		return
+	}
+
 	curser := sitter.NewTreeCursor(node)
 	curser.GoToFirstChild()
 	for curser.GoToNextSibling() {

--- a/internal/adapter/yamlls/trimTemplate_test.go
+++ b/internal/adapter/yamlls/trimTemplate_test.go
@@ -242,9 +242,19 @@ metadata:
       `,
 	},
 	{
-		// todo: Handle this case better
 		documentText: `{{ if }}{{- end -}}`,
-		trimmedText:  `      }}           `,
+		trimmedText:  `                   `,
+	},
+	{
+		// todo: Handle this case better
+		documentText: `
+{{ if }}
+
+{{- end -}}`,
+		trimmedText: `
+      }}
+
+           `,
 	},
 	{
 		documentText: `{{- $shards := $.Values.shards | int }}`,
@@ -361,6 +371,14 @@ list:
             - name: ELASTICSEARCH_HTTP_PORT_NUMBER
               value: {{ .Values.containerPorts.restAPI | quote }}
 `,
+	},
+	{
+		documentText: `
+apiVersion: {{ if .Values.useStatefulSet }}{{ include "common.capabilities.statefulset.apiVersion" . }}{{- else }}{{ include "common.capabilities.deployment.apiVersion" . }}{{- end }}
+    `,
+		trimmedText: `
+apiVersion:                                                                                                                                                                            
+    `,
 	},
 }
 

--- a/internal/adapter/yamlls/trimTemplate_test.go
+++ b/internal/adapter/yamlls/trimTemplate_test.go
@@ -1,9 +1,11 @@
 package yamlls
 
 import (
+	"fmt"
 	"testing"
 
 	lsplocal "github.com/mrjosh/helm-ls/internal/lsp"
+	"github.com/stretchr/testify/assert"
 )
 
 type TrimTemplateTestData struct {
@@ -296,6 +298,40 @@ data:
            
 `,
 	},
+	{
+		documentText: `
+{{- /*
+Copyright Some Company, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+`,
+		trimmedText: `
+      
+                            
+                                   
+    
+`,
+	},
+	{
+		documentText: `
+{{- $namespaces := list .Release.Namespace }}
+{{- $namespaces = .Values.controller.workflowNamespaces }}
+`,
+		trimmedText: `
+                                             
+                                                          
+`,
+	},
+	{
+		documentText: `
+{{- range $namespaces }}
+{{- end }}
+`,
+		trimmedText: `
+                       
+          
+`,
+	},
 }
 
 func TestTrimTemplate(t *testing.T) {
@@ -312,11 +348,5 @@ func testTrimTemplateWithTestData(t *testing.T, testData TrimTemplateTestData) {
 
 	trimmed := trimTemplateForYamllsFromAst(doc.Ast, testData.documentText)
 
-	result := trimmed == testData.trimmedText
-
-	if !result {
-		t.Errorf("Trimmed templated was not as expected but was %s ", trimmed)
-	} else {
-		t.Log("Trimmed templated was as expected")
-	}
+	assert.Equal(t, testData.trimmedText, trimmed, fmt.Sprintf("AST was: %v", doc.Ast.RootNode().String()))
 }

--- a/internal/adapter/yamlls/trimTemplate_test.go
+++ b/internal/adapter/yamlls/trimTemplate_test.go
@@ -328,8 +328,38 @@ SPDX-License-Identifier: APACHE-2.0
 {{- end }}
 `,
 		trimmedText: `
-                       
+                        
           
+`,
+	},
+	{
+		documentText: `
+list:
+  - value: {{ join "," .Values.initialCluster | quote }}
+  - name: some
+`,
+		trimmedText: `
+list:
+  - value: {{ join "," .Values.initialCluster | quote }}
+  - name: some
+`,
+	},
+	{
+		documentText: `
+            - name: ELASTICSEARCH_NODE_ROLES
+              value: {{ join "," $roles | quote }}
+            - name: ELASTICSEARCH_TRANSPORT_PORT_NUMBER
+              value: {{ .Values.containerPorts.transport | quote }}
+            - name: ELASTICSEARCH_HTTP_PORT_NUMBER
+              value: {{ .Values.containerPorts.restAPI | quote }}
+`,
+		trimmedText: `
+            - name: ELASTICSEARCH_NODE_ROLES
+              value: {{ join "," $roles | quote }}
+            - name: ELASTICSEARCH_TRANSPORT_PORT_NUMBER
+              value: {{ .Values.containerPorts.transport | quote }}
+            - name: ELASTICSEARCH_HTTP_PORT_NUMBER
+              value: {{ .Values.containerPorts.restAPI | quote }}
 `,
 	},
 }

--- a/internal/tree-sitter/gotemplate/node-types.go
+++ b/internal/tree-sitter/gotemplate/node-types.go
@@ -1,6 +1,7 @@
 package gotemplate
 
 const (
+	NodeTypeAssignment               = "assignment"
 	NodeTypeBlock                    = "block"
 	NodeTypeBlockAction              = "block_action"
 	NodeTypeChainedPipeline          = "chained_pipeline"


### PR DESCRIPTION
Tested with: 

https://github.com/bitnami/charts

Charts with names starting with a - p


unknown if a problem/if fixable:
- YAML: Yamlls: Block scalars with more-indented leading empty lines must use an explicit indentation indicator [0]
- templates ending with `| quote }}` often cause problems
- YAML: Yamlls: Block scalars with more-indented leading empty lines must use an explicit indentation indicator [0]


FYI @Mo0rBy.