### PR TITLE
feat(symbol-table): read in template context with variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test:
 	@$(GO) test ./... -v -race -tags=integration
 
 coverage:
-	@$(GO) test -coverprofile=.coverage -tags=integration ./internal/... && go tool cover -html=.coverage
+	@$(GO) test -coverprofile=.coverage -tags=integration -coverpkg=./internal/... ./internal/... && go tool cover -html=.coverage
 
 .PHONY: build-release
 build-release:

--- a/internal/handler/hover_main_test.go
+++ b/internal/handler/hover_main_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,6 +23,24 @@ func TestHoverMain(t *testing.T) {
 		expected      string
 		expectedError error
 	}{
+		{
+			desc: "Test hover on template context with variables",
+			position: lsp.Position{
+				Line:      74,
+				Character: 50,
+			},
+			expected:      "$root.Values.deployments",
+			expectedError: nil,
+		},
+		{
+			desc: "Test hover on template context with variables in range loop",
+			position: lsp.Position{
+				Line:      80,
+				Character: 35,
+			},
+			expected:      "$config.hpa.minReplicas",
+			expectedError: nil,
+		},
 		{
 			desc: "Test hover on dot",
 			position: lsp.Position{
@@ -113,15 +130,6 @@ func TestHoverMain(t *testing.T) {
 			},
 			expected:      fmt.Sprintf("### %s\n%s\n\n", filepath.Join("..", "..", "testdata", "example", "values.yaml"), "1"),
 			expectedError: nil,
-		},
-		{
-			desc: "Test hover on template context with variables",
-			position: lsp.Position{
-				Line:      74,
-				Character: 50,
-			},
-			expected:      "",
-			expectedError: errors.New("no template context found"),
 		},
 	}
 	for _, tt := range testCases {

--- a/internal/lsp/symbol_table.go
+++ b/internal/lsp/symbol_table.go
@@ -18,7 +18,7 @@ func (t TemplateContext) Tail() TemplateContext {
 }
 
 func (t TemplateContext) IsVariable() bool {
-	return len(t) > 0 && t[0] == "$"
+	return len(t) > 0 && strings.HasPrefix(t[0], "$")
 }
 
 func (t TemplateContext) AppendSuffix(suffix string) TemplateContext {

--- a/internal/lsp/symbol_table.go
+++ b/internal/lsp/symbol_table.go
@@ -45,7 +45,12 @@ func NewSymbolTable(ast *sitter.Tree, content []byte) *SymbolTable {
 }
 
 func (s *SymbolTable) AddTemplateContext(templateContext TemplateContext, pointRange sitter.Range) {
-	s.contexts[templateContext.Format()] = append(s.contexts[strings.Join(templateContext, ".")], pointRange)
+	if templateContext.IsVariable() && templateContext[0] == "$" {
+		// $ is a special variable that resolves to the root context
+		// we can just remove it from the template context
+		templateContext = templateContext.Tail()
+	}
+	s.contexts[templateContext.Format()] = append(s.contexts[templateContext.Format()], pointRange)
 	sliceCopy := make(TemplateContext, len(templateContext))
 	copy(sliceCopy, templateContext)
 	s.contextsReversed[pointRange] = sliceCopy

--- a/internal/lsp/symbol_table_template_context.go
+++ b/internal/lsp/symbol_table_template_context.go
@@ -67,8 +67,12 @@ func (v *TemplateContextVisitor) Enter(node *sitter.Node) {
 			GetRangeForNode(node.Child(int(node.ChildCount())-1)))
 	case gotemplate.NodeTypeSelectorExpression:
 		operandNode := node.ChildByFieldName("operand")
-		if operandNode.Type() == gotemplate.NodeTypeVariable && operandNode.Content(v.content) == "$" {
+		if operandNode.Type() == gotemplate.NodeTypeVariable {
 			v.StashContext()
+			if operandNode.Content(v.content) != "$" {
+				v.symbolTable.AddTemplateContext(append(v.currentContext, operandNode.Content(v.content)), GetRangeForNode(operandNode))
+				v.PushContext(operandNode.Content(v.content))
+			}
 		}
 	}
 }
@@ -77,7 +81,10 @@ func (v *TemplateContextVisitor) Exit(node *sitter.Node) {
 	switch node.Type() {
 	case gotemplate.NodeTypeSelectorExpression, gotemplate.NodeTypeUnfinishedSelectorExpression:
 		operandNode := node.ChildByFieldName("operand")
-		if operandNode.Type() == gotemplate.NodeTypeVariable && operandNode.Content(v.content) == "$" {
+		if operandNode.Type() == gotemplate.NodeTypeVariable {
+			if operandNode.Content(v.content) != "$" {
+				v.PopContext()
+			}
 			v.RestoreStashedContext()
 		}
 	}
@@ -97,7 +104,9 @@ func (v *TemplateContextVisitor) EnterContextShift(node *sitter.Node, suffix str
 			s = s.AppendSuffix(suffix)
 			if s.IsVariable() {
 				v.StashContext()
-				s = s.Tail()
+				if s[0] == "$" {
+					s = s.Tail()
+				}
 			}
 		}
 		v.PushContextMany(s)

--- a/internal/lsp/symbol_table_template_context_test.go
+++ b/internal/lsp/symbol_table_template_context_test.go
@@ -14,15 +14,39 @@ func TestGetContextForSelectorExpression(t *testing.T) {
 		expected    TemplateContext
 	}{
 		{
-			desc:        "Selects single selector expression correctly",
+			desc:        "Selects simple selector expression correctly",
 			template:    `{{ .Values.test }}`,
 			nodeContent: ".Values.test",
 			expected:    TemplateContext{"Values", "test"},
 		},
 		{
+			desc:        "Selects unfinished selector expression correctly",
+			template:    `{{ .Values.test. }}`,
+			nodeContent: ".Values.test.",
+			expected:    TemplateContext{"Values", "test"},
+		},
+		{
+			desc:        "Selects selector expression with $ correctly",
+			template:    `{{ $.Values.test }}`,
+			nodeContent: "$.Values.test",
+			expected:    TemplateContext{"$", "Values", "test"},
+		},
+		{
+			desc:        "Selects unfinished selector expression with $ correctly",
+			template:    `{{ $.Values.test. }}`,
+			nodeContent: "$.Values.test.",
+			expected:    TemplateContext{"$", "Values", "test"},
+		},
+		{
 			desc:        "Selects selector expression with variable correctly",
 			template:    `{{ $x.test }}`,
 			nodeContent: "$x.test",
+			expected:    TemplateContext{"$x", "test"},
+		},
+		{
+			desc:        "Selects unfinished selector expression with variable correctly",
+			template:    `{{ $x.test. }}`,
+			nodeContent: "$x.test.",
 			expected:    TemplateContext{"$x", "test"},
 		},
 	}

--- a/internal/lsp/symbol_table_template_context_test.go
+++ b/internal/lsp/symbol_table_template_context_test.go
@@ -1,0 +1,40 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetContextForSelectorExpression(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		template    string
+		nodeContent string
+		expected    TemplateContext
+	}{
+		{
+			desc:        "Selects single selector expression correctly",
+			template:    `{{ .Values.test }}`,
+			nodeContent: ".Values.test",
+			expected:    TemplateContext{"Values", "test"},
+		},
+		{
+			desc:        "Selects selector expression with variable correctly",
+			template:    `{{ $x.test }}`,
+			nodeContent: "$x.test",
+			expected:    TemplateContext{"$x", "test"},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			ast := ParseAst(nil, tC.template)
+			node := ast.RootNode().Child(1)
+
+			assert.Equal(t, tC.nodeContent, node.Content([]byte(tC.template)))
+			result := getContextForSelectorExpression(node, []byte(tC.template))
+
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/lsp/symbol_table_test.go
+++ b/internal/lsp/symbol_table_test.go
@@ -224,6 +224,28 @@ func TestSymbolTableForValuesSingleTests(t *testing.T) {
 
 	testCases := []testCase{
 		{
+			template: `
+      {{- $root := . -}}
+      {{- range $type, $config := $root.Values.deployments }}
+				{{- .InLoop }}
+			{{- end }}
+			{{ .Values.test }}
+`,
+			path: []string{"$root", "Values"},
+			startPoint: sitter.Point{
+				Row:    2,
+				Column: 40,
+			},
+		},
+		{
+			template: `{{ $x := .Values }}{{ $x.test }}{{ .Values.test }}`,
+			path:     []string{"$x", "test"},
+			startPoint: sitter.Point{
+				Row:    0,
+				Column: 25,
+			},
+		},
+		{
 			template: `{{ if (and .Values. ) }} {{ end }} `,
 			path:     []string{"Values"},
 			startPoint: sitter.Point{

--- a/internal/lsp/visitor.go
+++ b/internal/lsp/visitor.go
@@ -43,7 +43,11 @@ func (v *Visitors) visitNodesRecursiveWithScopeShift(node *sitter.Node) {
 	case gotemplate.NodeTypeRangeAction:
 		rangeNode := node.ChildByFieldName("range")
 		if rangeNode == nil {
-			break // range is optional (e.g. {{ range $index, $element := pipeline }})
+			rangeNode = node.NamedChild(0).ChildByFieldName("range")
+			if rangeNode == nil {
+				logger.Error("Could not find range node")
+				break
+			}
 		}
 		v.visitNodesRecursiveWithScopeShift(rangeNode)
 		for _, visitor := range v.visitors {

--- a/internal/lsp/visitor.go
+++ b/internal/lsp/visitor.go
@@ -43,6 +43,8 @@ func (v *Visitors) visitNodesRecursiveWithScopeShift(node *sitter.Node) {
 	case gotemplate.NodeTypeRangeAction:
 		rangeNode := node.ChildByFieldName("range")
 		if rangeNode == nil {
+			// for {{- range $type, $config := $root.Values.deployments }} the range node is in the
+			// range_variable_definition node an not in the range_action node
 			rangeNode = node.NamedChild(0).ChildByFieldName("range")
 			if rangeNode == nil {
 				logger.Error("Could not find range node")

--- a/testdata/example/templates/deployment.yaml
+++ b/testdata/example/templates/deployment.yaml
@@ -79,6 +79,6 @@ spec:
         name: my-app-{{ $type }}
       spec:
         replicas: {{ $config.hpa.minReplicas }}
-          {{ $.Values.ingress.hosts }}
+        test:  {{ $.Values.ingress.hosts }}
       ---
       {{- end }}

--- a/testdata/example/templates/deployment.yaml
+++ b/testdata/example/templates/deployment.yaml
@@ -79,5 +79,6 @@ spec:
         name: my-app-{{ $type }}
       spec:
         replicas: {{ $config.hpa.minReplicas }}
+          {{ $.Values.ingress.hosts }}
       ---
       {{- end }}


### PR DESCRIPTION
First part for https://github.com/mrjosh/helm-ls/issues/84. 

The symbol table should now store template contexts with variables correctly. Resolving the variables will be done separately.