### PR TITLE
fix(completion): {{.Something.}} gets correct completions

### DIFF
--- a/internal/handler/completion_main_test.go
+++ b/internal/handler/completion_main_test.go
@@ -164,6 +164,7 @@ func TestCompletionMainSingleLines(t *testing.T) {
 		notExpectedInsertTexts []string
 		err                    error
 	}{
+		{"Test completion on {{.Bad.^}}", []string{}, []string{}, errors.New("[Bad ] is no valid template context for helm")},
 		{"Test completion on {{ .Bad.^ }}", []string{}, []string{}, errors.New("[Bad ] is no valid template context for helm")},
 		{"Test completion on {{ n^ }}", []string{"not"}, []string{}, nil},
 		{"Test completion on {{ .Values.^ }}", []string{"replicaCount"}, []string{}, nil},

--- a/internal/lsp/ast.go
+++ b/internal/lsp/ast.go
@@ -24,7 +24,7 @@ func NestedNodeAtPositionForCompletion(tree *sitter.Tree, position lsp.Position)
 	currentNode := NodeAtPosition(tree, position)
 	pointToLoopUp := sitter.Point{
 		Row:    position.Line,
-		Column: position.Character,
+		Column: position.Character - 1,
 	}
 	return FindRelevantChildNodeCompletion(currentNode, pointToLoopUp)
 }


### PR DESCRIPTION
even without spaces before and after the brackets