### PR TITLE
feat: implement DidChangeConfiguration to reload yamlls configuration

### DIFF
--- a/internal/handler/configuration.go
+++ b/internal/handler/configuration.go
@@ -11,8 +11,9 @@ import (
 )
 
 func (h *ServerHandler) DidChangeConfiguration(ctx context.Context, params *lsp.DidChangeConfigurationParams) (err error) {
-	// go h.retrieveWorkspaceConfiguration(ctx)
-	logger.Println("Changing workspace config is not implemented")
+	logger.Println("Reload yaml configuration:", params)
+	h.helmlsConfig.YamllsConfiguration.YamllsSettings = params.Settings
+	h.configureYamlls(ctx)
 	return nil
 }
 


### PR DESCRIPTION
While developing a neovim plugin, I noticed that the method `DidChangeConfiguration` was not implemented.
Whereas on yamlls it is.
My suggestion is to trigger yamlls config reload on this method.
