### PR TITLE
fix: use CompletionItemKindSnippet for snippets

### DIFF
--- a/internal/protocol/completion.go
+++ b/internal/protocol/completion.go
@@ -45,7 +45,7 @@ func snippetCompletionItem(gotemplateSnippet godocs.GoTemplateSnippet) lsp.Compl
 		InsertText:       gotemplateSnippet.Snippet,
 		Detail:           gotemplateSnippet.Detail,
 		Documentation:    gotemplateSnippet.Doc,
-		Kind:             lsp.CompletionItemKindText,
+		Kind:             lsp.CompletionItemKindSnippet,
 		InsertTextFormat: lsp.InsertTextFormatSnippet,
 	}
 }


### PR DESCRIPTION
This is required for snippets to work with https://github.com/Saghen/blink.cmp