### PR TITLE
fix(values): do values files detection on the server

### DIFF
--- a/internal/handler/text_document.go
+++ b/internal/handler/text_document.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/mrjosh/helm-ls/internal/charts"
 	"github.com/mrjosh/helm-ls/internal/lsp/document"
@@ -10,10 +11,10 @@ import (
 )
 
 func (h *ServerHandler) DidOpen(ctx context.Context, params *lsp.DidOpenTextDocumentParams) (err error) {
-	handler := h.langHandlers[document.TemplateDocumentTypeForLangID(params.TextDocument.LanguageID)]
+	handler := h.langHandlers[document.DocumentTypeForFile(params.TextDocument.LanguageID, params.TextDocument.URI)]
 
 	if handler == nil {
-		message := "Language not supported: " + string(params.TextDocument.LanguageID)
+		message := fmt.Sprintf("Language or file not supported: %s, %v", params.TextDocument.LanguageID, params.TextDocument.URI)
 		logger.Error(message)
 		return errors.New(message)
 	}

--- a/internal/handler/yaml_handler/schema_provider.go
+++ b/internal/handler/yaml_handler/schema_provider.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/mrjosh/helm-ls/internal/lsp/document"
 	"go.lsp.dev/uri"
 )
 
 func (h *YamlHandler) CustomSchemaProvider(ctx context.Context, URI uri.URI) (uri.URI, error) {
 	if h.jsonSchemas == nil {
 		return uri.New(""), fmt.Errorf("JSON schema generator not initialized")
+	}
+
+	if !document.IsValuesYamlFile(URI) {
+		return uri.New(""), nil
 	}
 
 	chart, err := h.chartStore.GetChartForDoc(URI)

--- a/internal/lsp/document/document_test.go
+++ b/internal/lsp/document/document_test.go
@@ -35,3 +35,50 @@ func TestDocumentStore(t *testing.T) {
 	assert.NotNil(doc)
 	assert.True(ok)
 }
+
+func TestDocumentDocumentTypeForFile(t *testing.T) {
+	testCases := []struct {
+		fileURI protocol.URI
+		langID  protocol.LanguageIdentifier
+		want    DocumentType
+	}{
+		{uri.File("test.yaml"), "helm", TemplateDocumentType},
+		{uri.File("somewhere/test.yaml"), "helm", TemplateDocumentType},
+		{uri.File("somewhere/test.yaml"), "helm-template", TemplateDocumentType},
+		{uri.File("test.yml"), "helm", TemplateDocumentType},
+		{uri.File("test.yaml"), "yaml", YamlDocumentType},
+		{uri.File("test.yml"), "yaml", YamlDocumentType},
+		{uri.File("values.yml"), "helm", YamlDocumentType},
+		{uri.File("values.dev.yml"), "helm", YamlDocumentType},
+		{uri.File("values.yaml"), "helm", YamlDocumentType},
+		{uri.File("values.dev.yaml"), "helm", YamlDocumentType},
+		{uri.File("templates/values.dev.yaml"), "helm", TemplateDocumentType},
+	}
+
+	for _, testCase := range testCases {
+		got := DocumentTypeForFile(testCase.langID, testCase.fileURI)
+		assert.Equal(t, testCase.want, got, "DocumentTypeForFile(%s, %s) = %s, want %s", testCase.langID, testCase.fileURI, got, testCase.want)
+	}
+}
+
+func TestIsValuesYamlFile(t *testing.T) {
+	testCases := []struct {
+		fileURI protocol.URI
+		want    bool
+	}{
+		{uri.File("values.yaml"), true},
+		{uri.File("values.yml"), true},
+		{uri.File("values.dev.yaml"), true},
+		{uri.File("values.dev.yml"), true},
+		{uri.File("values.yaml"), true},
+		{uri.File("values.dev.yaml"), true},
+		{uri.File("templates/values.dev.yaml"), false},
+		{uri.File("deployment.yaml"), false},
+		{uri.File("templates/deployment.yaml"), false},
+	}
+
+	for _, testCase := range testCases {
+		got := IsValuesYamlFile(testCase.fileURI)
+		assert.Equal(t, testCase.want, got, "IsValuesYamlFile(%s) = %t, want %t", testCase.fileURI, got, testCase.want)
+	}
+}


### PR DESCRIPTION
This allows an editor (e.g. Zed) to just send the filetype helm for all file (including values.yaml) and the server will detect if it is a values.yaml file or not.

https://github.com/zed-industries/zed/pull/32369