### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -16,6 +16,8 @@ on:
 jobs:
   artifacts:
     name: artifacts
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: [1.23]


### PR DESCRIPTION
Potential fix for [https://github.com/mrjosh/helm-ls/security/code-scanning/6](https://github.com/mrjosh/helm-ls/security/code-scanning/6)

To fix the issue, explicitly limit the permissions for the `artifacts` job. Add a `permissions` block with the minimal required privileges. Based on the workflow's operations, the `artifacts` job seems to need read access to the repository contents for building artifacts. Therefore, the `contents: read` permission is sufficient. 

The `permissions` block will be added to the `artifacts` job definition (line 18). This ensures that the job has only the permissions it needs, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
