### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mrjosh/helm-ls/security/code-scanning/5](https://github.com/mrjosh/helm-ls/security/code-scanning/5)

To fix this problem, add a `permissions` block to the workflow file specifying the least privilege required for the linting job. Since the job only needs to check out code and run linting, it only needs `contents: read`. The `permissions` block can be added at the workflow root to apply to all jobs, or at the job level for `golangci`. The preferred approach is to add it at the workflow root (just after the `name:` and before `on:`) to ensure all jobs inherit these minimal permissions unless they specifically override them. No other functional changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
