### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mrjosh/helm-ls/security/code-scanning/4](https://github.com/mrjosh/helm-ls/security/code-scanning/4)

To resolve the issue, add a `permissions` block to the workflow. Since the workflow only installs dependencies, checks out code, and runs tests, it likely only requires read access to repository contents. To apply least privilege, the `contents: read` permission should be explicitly set at the root level of the workflow.

Steps:
1. Add the `permissions` key at the root level of the workflow file.
2. Set the `contents: read` permission.
3. Ensure the `permissions` block applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
