### PR TITLE
feat(values): lint unused values in values.yaml

### DIFF
--- a/internal/helm_lint/values_lint.go
+++ b/internal/helm_lint/values_lint.go
@@ -1,0 +1,87 @@
+package helmlint
+
+import (
+	"fmt"
+
+	"github.com/goccy/go-yaml/ast"
+	"github.com/mrjosh/helm-ls/internal/charts"
+	"github.com/mrjosh/helm-ls/internal/lsp/document"
+	"github.com/mrjosh/helm-ls/internal/lsp/symboltable"
+	"github.com/mrjosh/helm-ls/internal/util"
+	lsp "go.lsp.dev/protocol"
+)
+
+func LintUnusedValues(chart *charts.Chart, doc *document.YamlDocument, templateDocs []*document.TemplateDocument) []lsp.Diagnostic {
+	if len(templateDocs) == 0 {
+		// TODO: delay linting until the template docs are loaded
+		return []lsp.Diagnostic{}
+	}
+
+	result := []lsp.Diagnostic{}
+	for _, node := range FindNodes(doc.GoccyYamlNode) {
+
+		templateContext := symboltable.TemplateContextFromYAMLPath(node.GetPath())
+		found := false
+
+		for _, templateDoc := range templateDocs {
+			// TODO(dependecy-charts): template context would need to be adjusted for dependency charts
+			// see https://github.com/mrjosh/helm-ls/issues/152
+			referenceRanges := templateDoc.SymbolTable.GetTemplateContextRanges(append([]string{"Values"}, templateContext...))
+
+			logger.Println(fmt.Sprintf("LintUnusedValues: checking template context %v in template doc %s", templateContext, templateDoc.GetPath()))
+
+			if len(referenceRanges) > 0 {
+				found = true
+				break
+			}
+		}
+
+		if found {
+			continue
+		}
+
+		fmt.Println(node.String())
+		result = append(result, lsp.Diagnostic{
+			Range:           util.TokenToRange(node.GetToken()),
+			Severity:        0,
+			Code:            nil,
+			CodeDescription: &lsp.CodeDescription{},
+			Source:          "",
+			Message:         fmt.Sprintf("Unused value: %s of type %s", node.GetPath(), node.Type()),
+			Tags: []lsp.DiagnosticTag{
+				lsp.DiagnosticTagUnnecessary,
+			},
+			RelatedInformation: []lsp.DiagnosticRelatedInformation{},
+			Data:               nil,
+		})
+	}
+
+	return result
+}
+
+func FindNodes(node ast.Node) []ast.Node {
+	visitor := &LeafMappingsFinderVisitor{}
+	ast.Walk(visitor, node)
+	return visitor.result
+}
+
+// PositionFinderVisitor is a visitor that collects positions.
+type LeafMappingsFinderVisitor struct {
+	result []ast.Node
+}
+
+func (v *LeafMappingsFinderVisitor) Visit(node ast.Node) ast.Visitor {
+	if IsLeafMapping(node) {
+		v.result = append(v.result, node)
+	}
+	return v
+}
+
+func IsLeafMapping(node ast.Node) bool {
+	switch node.Type() {
+	case ast.MappingKeyType, ast.MappingValueType, ast.MappingType, ast.SequenceType:
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/helm_lint/values_lint.go
+++ b/internal/helm_lint/values_lint.go
@@ -43,10 +43,10 @@ func LintUnusedValues(chart *charts.Chart, doc *document.YamlDocument, templateD
 		fmt.Println(node.String())
 		result = append(result, lsp.Diagnostic{
 			Range:           util.TokenToRange(node.GetToken()),
-			Severity:        0,
+			Severity:        lsp.DiagnosticSeverityHint,
 			Code:            nil,
 			CodeDescription: &lsp.CodeDescription{},
-			Source:          "",
+			Source:          "helm-ls unused values",
 			Message:         fmt.Sprintf("Unused value: %s of type %s", node.GetPath(), node.Type()),
 			Tags: []lsp.DiagnosticTag{
 				lsp.DiagnosticTagUnnecessary,

--- a/internal/helm_lint/values_lint.go
+++ b/internal/helm_lint/values_lint.go
@@ -40,7 +40,6 @@ func LintUnusedValues(chart *charts.Chart, doc *document.YamlDocument, templateD
 			continue
 		}
 
-		fmt.Println(node.String())
 		result = append(result, lsp.Diagnostic{
 			Range:           util.TokenToRange(node.GetToken()),
 			Severity:        lsp.DiagnosticSeverityHint,

--- a/internal/util/yaml_goccy.go
+++ b/internal/util/yaml_goccy.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/token"
 	"go.lsp.dev/protocol"
+	lsp "go.lsp.dev/protocol"
 )
 
 func GetNodeForPosition(node ast.Node, position protocol.Position) ast.Node {
@@ -82,4 +84,15 @@ func ReadYamlToGoccyNode(data []byte) (node ast.Node, err error) {
 
 	err = yaml.Unmarshal(normalizedData, &node)
 	return node, err
+}
+
+func TokenToRange(token *token.Token) lsp.Range {
+	if token == nil {
+		return lsp.Range{}
+	}
+
+	return lsp.Range{
+		Start: lsp.Position{Line: uint32(token.Position.Line - 1), Character: uint32(token.Position.Column - 1)},
+		End:   lsp.Position{Line: uint32(token.Position.Line - 1), Character: uint32(token.Position.Column+len(token.Value)) + 1},
+	}
 }


### PR DESCRIPTION
First draft for https://github.com/mrjosh/helm-ls/issues/176

Currently only runs correctly when you safe the file after it was opened.

<img width="659" height="220" alt="image" src="https://github.com/user-attachments/assets/be62a451-3c0a-4b19-9ce1-d54dcced1267" />


- [ ] Make it configurable
- [ ] What about subcharts?
- [ ] Tests
- [ ] Run it after all templates were loaded